### PR TITLE
Fix Error 0x8007000E Out of memory

### DIFF
--- a/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
+++ b/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
@@ -225,6 +225,7 @@ namespace HyperionScreenCap
             finally
             {
                 screenResource?.Dispose();
+                _device.ImmediateContext.UnmapSubresource(_stagingTexture, 0);
                 // Ignore DXGI_ERROR_INVALID_CALL, DXGI_ERROR_ACCESS_LOST errors since capture is already complete
                 try { _duplicatedOutput.ReleaseFrame(); } catch { }
             }


### PR DESCRIPTION
Resolve #5 by unmapping the previously mapped `_stagingTexture` after use in `ToRGBArray()`.