### PR TITLE
Add HDR support to DX11 Capture

### DIFF
--- a/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
+++ b/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
@@ -273,6 +273,8 @@ namespace HyperionScreenCap
 
         public static float Parse16BitFloat(byte Hi, byte Lo)
         {
+            // From https://stackoverflow.com/questions/6162651/half-precision-floating-point-in-java/6162687#6162687
+
             int fullFloat = ((Hi << 8) | Lo);
             int mant = fullFloat & 0x03ff;            // 10 bits mantissa
             int exp =  fullFloat & 0x7c00;            // 5 bits exponent

--- a/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
+++ b/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
@@ -383,23 +383,12 @@ namespace HyperionScreenCap
                     foreach ( Int32 pixelData in rowData )
                     {
                         Int32 r = pixelData & 0x3FF;
-                        Int32 b = (pixelData >> 10) & 0x3FF;
-                        Int32 g = (pixelData >> 20) & 0x3FF;
+                        Int32 g = (pixelData >> 10) & 0x3FF;
+                        Int32 b = (pixelData >> 20) & 0x3FF;
 
-                        if ( BitConverter.IsLittleEndian )
-                        {
-                            // Byte order : bgra
-                            bytes[byteIndex++] = convert10bitTo8bit(b);
-                            bytes[byteIndex++] = convert10bitTo8bit(g);
-                            bytes[byteIndex++] = convert10bitTo8bit(r);
-                        }
-                        else
-                        {
-                            // Byte order : argb
-                            bytes[byteIndex++] = convert10bitTo8bit(r);
-                            bytes[byteIndex++] = convert10bitTo8bit(g);
-                            bytes[byteIndex++] = convert10bitTo8bit(b);
-                        }
+                        bytes[byteIndex++] = convert10bitTo8bit(r);
+                        bytes[byteIndex++] = convert10bitTo8bit(g);
+                        bytes[byteIndex++] = convert10bitTo8bit(b);
                     }
 
                     sourcePtr = IntPtr.Add(sourcePtr, mapSource.RowPitch);

--- a/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
+++ b/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
@@ -1,7 +1,8 @@
 ﻿using HyperionScreenCap.Capture;
-using SharpDX;
-using SharpDX.Direct3D11;
-using SharpDX.DXGI;
+using Vortice;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,9 +13,24 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using static Vortice.Direct3D11.D3D11;
+using static Vortice.DXGI.DXGI;
+
+
 
 namespace HyperionScreenCap
 {
+
+    static class MathExt
+    {
+        public static T Clamp<T>(this T val, T min, T max) where T : IComparable<T>
+        {
+            if (val.CompareTo(min) < 0) return min;
+            else if (val.CompareTo(max) > 0) return max;
+            else return val;
+        }
+    }
+
     class DX11ScreenCapture : IScreenCapture
     {
         private int _adapterIndex;
@@ -23,15 +39,15 @@ namespace HyperionScreenCap
         private int _maxFps;
         private int _frameCaptureTimeout;
 
-        private Factory1 _factory;
-        private Adapter _adapter;
-        private Output _output;
-        private Output1 _output1;
-        private SharpDX.Direct3D11.Device _device;
-        private Texture2D _stagingTexture;
-        private Texture2D _smallerTexture;
-        private ShaderResourceView _smallerTextureView;
-        private OutputDuplication _duplicatedOutput;
+        private IDXGIFactory2 _factory;
+        private IDXGIAdapter1 _adapter;
+        private IDXGIOutput _output;
+        private IDXGIOutput5 _output5;
+        private ID3D11Device _device;
+        private ID3D11Texture2D _stagingTexture;
+        private ID3D11Texture2D _smallerTexture;
+        private ID3D11ShaderResourceView _smallerTextureView;
+        private IDXGIOutputDuplication _duplicatedOutput;
         private int _scalingFactorLog2;
         private int _width;
         private int _height;
@@ -40,6 +56,10 @@ namespace HyperionScreenCap
         private Stopwatch _captureTimer;
         private bool _desktopDuplicatorInvalid;
         private bool _disposed;
+        private static readonly FeatureLevel[] s_featureLevels = new[]
+        {
+            FeatureLevel.Level_11_0
+        };
 
         public int CaptureWidth { get; private set; }
         public int CaptureHeight { get; private set; }
@@ -47,22 +67,25 @@ namespace HyperionScreenCap
         public static String GetAvailableMonitors()
         {
             StringBuilder response = new StringBuilder();
-            using ( Factory1 factory = new Factory1() )
+            IDXGIFactory2 tempFactory = null;
+            DXGI.CreateDXGIFactory2(false,out tempFactory);
+            //using ( IDXGIFactory2 factory = new IDXGIFactory2() )
             {
                 int adapterIndex = 0;
-                foreach(Adapter adapter in factory.Adapters)
+                while(tempFactory.EnumAdapters(adapterIndex, out IDXGIAdapter adapter) == SharpGen.Runtime.Result.Ok)
                 {
                     response.Append($"Adapter Index {adapterIndex++}: {adapter.Description.Description}\n");
                     int outputIndex = 0;
-                    foreach(Output output in adapter.Outputs)
+                    while(adapter.EnumOutputs(outputIndex, out IDXGIOutput output) == SharpGen.Runtime.Result.Ok)
                     {
                         response.Append($"\tMonitor Index {outputIndex++}: {output.Description.DeviceName}");
-                        var desktopBounds = output.Description.DesktopBounds;
+                        var desktopBounds = output.Description.DesktopCoordinates;
                         response.Append($" {desktopBounds.Right - desktopBounds.Left}×{desktopBounds.Bottom - desktopBounds.Top}\n");
                     }
                     response.Append("\n");
                 }
             }
+            tempFactory.Dispose();
             return response.ToString();
         }
 
@@ -91,19 +114,19 @@ namespace HyperionScreenCap
             else
                 throw new Exception("Invalid scaling factor. Allowed valued are 1, 2, 4, etc.");
 
-            // Create DXGI Factory1
-            _factory = new Factory1();
-            _adapter = _factory.GetAdapter1(_adapterIndex);
+            // Create DXGI IDXGIFactory2
+            DXGI.CreateDXGIFactory2(false,out _factory);
+            _factory.EnumAdapters1(_adapterIndex, out _adapter);
 
             // Create device from Adapter
-            _device = new SharpDX.Direct3D11.Device(_adapter);
+            D3D11CreateDevice(_adapter, DriverType.Unknown, /*DeviceCreationFlags.BgraSupport*/ DeviceCreationFlags.None, s_featureLevels, out _device);
 
             // Get DXGI.Output
-            _output = _adapter.GetOutput(_monitorIndex);
-            _output1 = _output.QueryInterface<Output1>();
+            _adapter.EnumOutputs(_monitorIndex, out _output);
+            _output5 = _output.QueryInterface<IDXGIOutput5>();
 
             // Width/Height of desktop to capture
-            var desktopBounds = _output.Description.DesktopBounds;
+            var desktopBounds = _output.Description.DesktopCoordinates;
             _width = desktopBounds.Right - desktopBounds.Left;
             _height = desktopBounds.Bottom - desktopBounds.Top;
 
@@ -113,35 +136,35 @@ namespace HyperionScreenCap
             // Create Staging texture CPU-accessible
             var stagingTextureDesc = new Texture2DDescription
             {
-                CpuAccessFlags = CpuAccessFlags.Read,
+                CPUAccessFlags = CpuAccessFlags.Read,
                 BindFlags = BindFlags.None,
-                Format = Format.B8G8R8A8_UNorm,
+                Format = Format.R16G16B16A16_Float,
                 Width = CaptureWidth,
                 Height = CaptureHeight,
-                OptionFlags = ResourceOptionFlags.None,
+                MiscFlags = ResourceOptionFlags.None,
                 MipLevels = 1,
                 ArraySize = 1,
                 SampleDescription = { Count = 1, Quality = 0 },
                 Usage = ResourceUsage.Staging
             };
-            _stagingTexture = new Texture2D(_device, stagingTextureDesc);
+            _stagingTexture = _device.CreateTexture2D(stagingTextureDesc);
 
             // Create smaller texture to downscale the captured image
             var smallerTextureDesc = new Texture2DDescription
             {
-                CpuAccessFlags = CpuAccessFlags.None,
+                CPUAccessFlags = CpuAccessFlags.None,
                 BindFlags = BindFlags.RenderTarget | BindFlags.ShaderResource,
-                Format = Format.B8G8R8A8_UNorm,
+                Format = Format.R16G16B16A16_Float,
                 Width = _width,
                 Height = _height,
-                OptionFlags = ResourceOptionFlags.GenerateMipMaps,
+                MiscFlags = ResourceOptionFlags.GenerateMips,
                 MipLevels = mipLevels,
                 ArraySize = 1,
                 SampleDescription = { Count = 1, Quality = 0 },
                 Usage = ResourceUsage.Default
             };
-            _smallerTexture = new Texture2D(_device, smallerTextureDesc);
-            _smallerTextureView = new ShaderResourceView(_device, _smallerTexture);
+            _smallerTexture = _device.CreateTexture2D(smallerTextureDesc);
+            _smallerTextureView = _device.CreateShaderResourceView(_smallerTexture);
 
             _minCaptureTime = 1000 / _maxFps;
             _captureTimer = new Stopwatch();
@@ -153,7 +176,8 @@ namespace HyperionScreenCap
         private void InitDesktopDuplicator()
         {
             // Duplicate the output
-            _duplicatedOutput = _output1.DuplicateOutput(_device);
+            Format[] DesktopFormats = {  Format.R16G16B16A16_Float, Format.B8G8R8A8_UNorm };
+            _duplicatedOutput = _output5.DuplicateOutput1(_device, DesktopFormats);
 
             _desktopDuplicatorInvalid = false;
         }
@@ -175,76 +199,206 @@ namespace HyperionScreenCap
 
         private byte[] ManagedCapture()
         {
-            SharpDX.DXGI.Resource screenResource = null;
-            OutputDuplicateFrameInformation duplicateFrameInformation;
+            IDXGIResource screenResource = null;
+            OutduplFrameInfo duplicateFrameInformation;
 
             try
             {
-                try
                 {
                     // Try to get duplicated frame within given time
-                    _duplicatedOutput.AcquireNextFrame(_frameCaptureTimeout, out duplicateFrameInformation, out screenResource);
+                    SharpGen.Runtime.Result res = _duplicatedOutput.AcquireNextFrame(_frameCaptureTimeout, out duplicateFrameInformation, out screenResource);
 
+                    if ( res == SharpGen.Runtime.Result.WaitTimeout.Code && _lastCapturedFrame != null )
+                        return _lastCapturedFrame;
+
+                    if (res == new SharpGen.Runtime.Result(0x887A0026)) // ACCESS_LOST
+                    {
+                        _desktopDuplicatorInvalid = true;
+                        return null;
+                    }
                     if ( duplicateFrameInformation.LastPresentTime == 0 && _lastCapturedFrame != null )
                         return _lastCapturedFrame;
-                }
-                catch ( SharpDXException ex )
-                {
-                    if ( ex.ResultCode.Code == SharpDX.DXGI.ResultCode.WaitTimeout.Code && _lastCapturedFrame != null )
-                        return _lastCapturedFrame;
-
-                    if ( ex.ResultCode.Code == SharpDX.DXGI.ResultCode.AccessLost.Code )
-                        _desktopDuplicatorInvalid = true;
-
-                    throw ex;
                 }
 
                 // Check if scaling is used
                 if ( CaptureWidth != _width )
                 {
                     // Copy resource into memory that can be accessed by the CPU
-                    using ( var screenTexture2D = screenResource.QueryInterface<Texture2D>() )
-                        _device.ImmediateContext.CopySubresourceRegion(screenTexture2D, 0, null, _smallerTexture, 0);
+                    using ( var screenTexture2D = screenResource.QueryInterface<ID3D11Texture2D>() )
+                        _device.ImmediateContext.CopySubresourceRegion(_smallerTexture, 0, 0, 0, 0, screenTexture2D, 0);
 
                     // Generates the mipmap of the screen
                     _device.ImmediateContext.GenerateMips(_smallerTextureView);
 
                     // Copy the mipmap of smallerTexture (size/ scalingFactor) to the staging texture: 1 for /2, 2 for /4...etc
-                    _device.ImmediateContext.CopySubresourceRegion(_smallerTexture, _scalingFactorLog2, null, _stagingTexture, 0);
+                    _device.ImmediateContext.CopySubresourceRegion(_stagingTexture, 0, 0, 0, 0, _smallerTexture, _scalingFactorLog2);
                 }
                 else
                 {
                     // Copy resource into memory that can be accessed by the CPU
-                    using ( var screenTexture2D = screenResource.QueryInterface<Texture2D>() )
+                    using ( var screenTexture2D = screenResource.QueryInterface<ID3D11Texture2D>() )
                         _device.ImmediateContext.CopyResource(screenTexture2D, _stagingTexture);
                 }
 
                 // Get the desktop capture texture
-                var mapSource = _device.ImmediateContext.MapSubresource(_stagingTexture, 0, MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
-                _lastCapturedFrame = ToRGBArray(mapSource);
+                MappedSubresource mapSource = _device.ImmediateContext.Map(_stagingTexture, 0, MapMode.Read);
+                _lastCapturedFrame = ToRGBArrayFast(mapSource);
                 return _lastCapturedFrame;
             }
             finally
             {
                 screenResource?.Dispose();
                 // Fixed OUT_OF_MEMORY issue on AMD Radeon cards. Ignoring all exceptions during unmapping.
-                try { _device.ImmediateContext.UnmapSubresource(_stagingTexture, 0); } catch { };
+                try { _device.ImmediateContext.Unmap(_stagingTexture, 0); } catch { };
                 // Ignore DXGI_ERROR_INVALID_CALL, DXGI_ERROR_ACCESS_LOST errors since capture is already complete
                 try { _duplicatedOutput.ReleaseFrame(); } catch { }
             }
         }
 
+        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory", SetLastError = false)]
+        static extern void CopyMemory(IntPtr Destination, IntPtr Source, uint Length);
+
+        public static unsafe void MemCopy(IntPtr ptrSource, ulong[] dest, uint elements)
+        {
+            fixed (ulong* ptrDest = &dest[0])
+            {
+                CopyMemory((IntPtr)ptrDest, ptrSource, elements * 8);    // 8 bytes per element
+            }
+        }
+    public static float Parse16BitFloat(byte HI, byte LO)
+        {
+            // Program assumes ints are at least 16 bits
+            int fullFloat = ((HI << 8) | LO);
+            int exponent = (HI & 0b01111110) >> 1; // minor optimisation can be placed here
+            int mant = fullFloat & 0x01FF;
+
+            // Special values
+            if (exponent == 0b00111111) // If using constants, shift right by 1
+            {
+                // Check for non or inf
+                return mant != 0 ? float.NaN :
+                    ((HI & 0x80) == 0 ? float.PositiveInfinity : float.NegativeInfinity);
+            }
+            else // normal/denormal values: pad numbers
+            {
+                exponent = exponent - 31 + 127;
+                mant = mant << 14;
+                Int32 finalFloat = (HI & 0x80) << 24 | (exponent << 23) | mant;
+                return BitConverter.ToSingle(BitConverter.GetBytes(finalFloat), 0);
+            }
+        }
+        public static float Parse16BitFloat2(byte Hi, byte Lo)
+        {
+            int fullFloat = ((Hi << 8) | Lo);
+            int mant = fullFloat & 0x03ff;            // 10 bits mantissa
+            int exp =  fullFloat & 0x7c00;            // 5 bits exponent
+            if( exp == 0x7c00 )                   // NaN/Inf
+                exp = 0x3fc00;                    // -> NaN/Inf
+            else if( exp != 0 )                   // normalized value
+            {
+                exp += 0x1c000;                   // exp - 15 + 127
+                if( mant == 0 && exp > 0x1c400 )  // smooth transition
+                    return BitConverter.ToSingle(BitConverter.GetBytes( ( fullFloat & 0x8000 ) << 16
+                                                    | exp << 13 | 0x3ff ), 0);
+            }
+            else if( mant != 0 )                  // && exp==0 -> subnormal
+            {
+                exp = 0x1c400;                    // make it normal
+                do {
+                    mant <<= 1;                   // mantissa * 2
+                    exp -= 0x400;                 // decrease exp by 1
+                } while( ( mant & 0x400 ) == 0 ); // while not normal
+                mant &= 0x3ff;                    // discard subnormal bit
+            }                                     // else +/-0 -> +/-0
+            return BitConverter.ToSingle(BitConverter.GetBytes(          // combine all parts
+                ( fullFloat & 0x8000 ) << 16          // sign  << ( 31 - 15 )
+                | ( exp | mant ) << 13 ), 0);         // value << ( 23 - 10 )
+        }
         /// <summary>
         /// Reads from the memory locations pointed to by the DataBox and saves it into a byte array
         /// ignoring the alpha component of each pixel.
         /// </summary>
         /// <param name="mapSource"></param>
         /// <returns></returns>
-        private byte[] ToRGBArray(DataBox mapSource)
+        private byte[] ToRGBArrayFast(MappedSubresource mapSource)
+        {
+            byte[] bytes = new byte[CaptureWidth * 3 * CaptureHeight];
+            int byteIndex = 0;
+            unsafe
+            {
+                byte* ptr = (byte*)mapSource.DataPointer;
+                byte* rowptr = ptr;
+                for ( int y = 0; y < CaptureHeight; y++ )
+                {
+                    byte* pixelptr = rowptr;
+                    for ( int x = 0; x < CaptureWidth; x++ )
+                    {
+                        for (int comp = 0; comp < 3; comp++ )
+                        {
+                            byte lo = *pixelptr++;
+                            byte hi = *pixelptr++;
+                            
+                            // No idea why these values range from 4.6 to 0 instead of 1 to 0
+                            // f(x) = sqrt(x/5) seems to approximate what the values should be.
+                            bytes[byteIndex++] =  (byte)(MathExt.Clamp(Math.Sqrt(Parse16BitFloat2(hi, lo)/4.6), 0, 1) * 255);
+                        }
+                        pixelptr += 2; //skip alpha
+                    }
+                    rowptr += mapSource.RowPitch;
+                }
+            }
+            return bytes;
+        }
+
+        private byte[] ToRGBArray(MappedSubresource mapSource)
         {
             var sourcePtr = mapSource.DataPointer;
             byte[] bytes = new byte[CaptureWidth * 3 * CaptureHeight];
             int byteIndex = 0;
+#if true
+            for ( int y = 0; y < CaptureHeight; y++ )
+            {
+                UInt64[] rowData = new UInt64[CaptureWidth];
+                MemCopy(sourcePtr, rowData, (uint)CaptureWidth);
+
+                foreach (Int64 pixelData in rowData)
+                {
+                    //Func<byte[], int, byte> Convert16bitTo8bit = (byteArray, index) => (byte)(((float)BitConverter.ToUInt16(byteArray, index) / (float)UInt16.MaxValue) * 255);
+                    Func<byte[], int, float, byte> Convert16bitTo8bit = (byteArray, index, scale) =>
+                    {
+                        //float raw = Parse16BitFloat(byteArray[index + 1], byteArray[index]);
+                        //float raw = Ieee11073ToSingle(byteArray[index + 1], byteArray[index]);
+                        float raw = Parse16BitFloat2(byteArray[index + 1], byteArray[index]);
+                        //double raw2 = raw <= 0.0031308 ? raw * 12.92 : 1.055 * Math.Pow(raw, 1.0f / 2.4f) - 0.055f;
+                        //double final = MathExt.Clamp(raw2, 0.0f, 1.0f);
+                        double final = MathExt.Clamp(raw, 0.0f, 1.0f);
+                        return (byte)(final * 255);
+                    };
+                    byte[] values = BitConverter.GetBytes(pixelData);
+                    if ( BitConverter.IsLittleEndian )
+                    {
+                        float alpha = Parse16BitFloat2(values[7], values[6]);
+                        float r = Parse16BitFloat2(values[1], values[0]);
+                        float g = Parse16BitFloat2(values[3], values[2]);
+                        float b = Parse16BitFloat2(values[5], values[4]);
+                        // Byte order : rgba
+                        bytes[byteIndex++] = Convert16bitTo8bit(values, 0, alpha);
+                        bytes[byteIndex++] = Convert16bitTo8bit(values, 2, alpha);
+                        bytes[byteIndex++] = Convert16bitTo8bit(values, 4, alpha);
+                    }
+                    else
+                    {
+                        float alpha = Parse16BitFloat(values[0], values[1]);
+                        // Byte order : abgr
+                        bytes[byteIndex++] = Convert16bitTo8bit(values, 6, alpha);
+                        bytes[byteIndex++] = Convert16bitTo8bit(values, 4, alpha);
+                        bytes[byteIndex++] = Convert16bitTo8bit(values, 2, alpha);
+                    }
+                }
+
+                sourcePtr = IntPtr.Add(sourcePtr, mapSource.RowPitch);
+            }
+#else
             for ( int y = 0; y < CaptureHeight; y++ )
             {
                 Int32[] rowData = new Int32[CaptureWidth];
@@ -271,6 +425,8 @@ namespace HyperionScreenCap
 
                 sourcePtr = IntPtr.Add(sourcePtr, mapSource.RowPitch);
             }
+#endif
+
             return bytes;
         }
 
@@ -286,7 +442,7 @@ namespace HyperionScreenCap
         public void Dispose()
         {
             _duplicatedOutput?.Dispose();
-            _output1?.Dispose();
+            _output5?.Dispose();
             _output?.Dispose();
             _stagingTexture?.Dispose();
             _smallerTexture?.Dispose();

--- a/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
+++ b/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
@@ -142,7 +142,7 @@ namespace HyperionScreenCap
             _smallerTextureView?.Dispose();
 
             // Duplicate the output
-            Format[] DesktopFormats = {  Format.R16G16B16A16_Float, Format.B8G8R8A8_UNorm };
+            Format[] DesktopFormats = {  Format.R16G16B16A16_Float, Format.B8G8R8A8_UNorm, Format.R10G10B10A2_UNorm};
             _duplicatedOutput = _output5.DuplicateOutput1(_device, 0, DesktopFormats.Count(), DesktopFormats);
 
             // Calculate miplevels

--- a/HyperionScreenCap/Helper/HyperionTask.cs
+++ b/HyperionScreenCap/Helper/HyperionTask.cs
@@ -139,8 +139,10 @@ namespace HyperionScreenCap.Helper
                 try
                 {
                     byte[] imageData = _screenCapture.Capture();
-                    hyperionClient.SendImageData(imageData, _screenCapture.CaptureWidth, _screenCapture.CaptureHeight);
-
+                    if (imageData != null)
+                    {
+                        hyperionClient.SendImageData(imageData, _screenCapture.CaptureWidth, _screenCapture.CaptureHeight);
+                    }
                     // Uncomment the following to enable debugging
                     // MiscUtils.SaveRGBArrayToImageFile(imageData, _screenCapture.CaptureWidth, _screenCapture.CaptureHeight, AppConstants.DEBUG_IMAGE_FILE_NAME);
                 }

--- a/HyperionScreenCap/HyperionScreenCap.csproj
+++ b/HyperionScreenCap/HyperionScreenCap.csproj
@@ -1,10 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props" Condition="Exists('..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props')" />
-  <Import Project="..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props" Condition="Exists('..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props')" />
-  <Import Project="..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props" Condition="Exists('..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props')" />
-  <Import Project="..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props" Condition="Exists('..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props')" />
-  <Import Project="..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props" Condition="Exists('..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props')" />
   <Import Project="..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" />
   <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -53,7 +48,6 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -63,7 +57,6 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -75,7 +68,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -116,9 +108,6 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.HashCode.1.1.1\lib\net461\Microsoft.Bcl.HashCode.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=3.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.3.8.0\lib\netstandard2.0\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
@@ -134,14 +123,18 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SharpGen.Runtime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a7c0d43f556c6402, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpGen.Runtime.2.0.0-beta.11\lib\net471\SharpGen.Runtime.dll</HintPath>
+    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>
-    <Reference Include="SharpGen.Runtime.COM, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a7c0d43f556c6402, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\lib\net45\SharpGen.Runtime.COM.dll</HintPath>
+    <Reference Include="SharpDX.Direct3D11, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Direct3D11.4.2.0\lib\net45\SharpDX.Direct3D11.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.DXGI.4.2.0\lib\net45\SharpDX.DXGI.dll</HintPath>
     </Reference>
     <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
       <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
@@ -184,8 +177,8 @@
     <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encoding.CodePages.5.0.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
@@ -200,21 +193,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Vortice.Direct3D11, Version=2.2.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Vortice.Direct3D11.2.2.0\lib\netstandard2.0\Vortice.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="Vortice.DirectX, Version=2.2.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Vortice.DirectX.2.2.0\lib\netstandard2.0\Vortice.DirectX.dll</HintPath>
-    </Reference>
-    <Reference Include="Vortice.DXGI, Version=2.2.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Vortice.DXGI.2.2.0\lib\netstandard2.0\Vortice.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="Vortice.Mathematics, Version=1.4.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Vortice.Mathematics.1.4.22\lib\netstandard2.0\Vortice.Mathematics.dll</HintPath>
-    </Reference>
-    <Reference Include="WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsBase_Core.STW.4.0.30319.1\lib\net40\WindowsBase.dll</HintPath>
-    </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiServer.cs" />
@@ -407,6 +386,9 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -416,11 +398,6 @@
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Fody.6.3.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.3.0\build\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props'))" />
-    <Error Condition="!Exists('..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props'))" />
-    <Error Condition="!Exists('..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props'))" />
-    <Error Condition="!Exists('..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props'))" />
-    <Error Condition="!Exists('..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props'))" />
   </Target>
   <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets')" />
   <Import Project="..\packages\Fody.6.3.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.3.0\build\Fody.targets')" />

--- a/HyperionScreenCap/HyperionScreenCap.csproj
+++ b/HyperionScreenCap/HyperionScreenCap.csproj
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props" Condition="Exists('..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props')" />
+  <Import Project="..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props" Condition="Exists('..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props')" />
+  <Import Project="..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props" Condition="Exists('..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props')" />
+  <Import Project="..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props" Condition="Exists('..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props')" />
+  <Import Project="..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props" Condition="Exists('..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props')" />
   <Import Project="..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" />
   <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -48,6 +53,7 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -57,6 +63,7 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -68,6 +75,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -78,6 +86,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
@@ -107,6 +116,9 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.HashCode.1.1.1\lib\net461\Microsoft.Bcl.HashCode.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=3.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.3.8.0\lib\netstandard2.0\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
@@ -125,14 +137,11 @@
     <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
+    <Reference Include="SharpGen.Runtime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a7c0d43f556c6402, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpGen.Runtime.2.0.0-beta.11\lib\net471\SharpGen.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct3D11, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Direct3D11.4.2.0\lib\net45\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.DXGI.4.2.0\lib\net45\SharpDX.DXGI.dll</HintPath>
+    <Reference Include="SharpGen.Runtime.COM, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a7c0d43f556c6402, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\lib\net45\SharpGen.Runtime.COM.dll</HintPath>
     </Reference>
     <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
       <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
@@ -163,8 +172,9 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Management" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Numerics" />
@@ -174,8 +184,8 @@
     <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encoding.CodePages.5.0.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
@@ -190,6 +200,21 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Vortice.Direct3D11, Version=2.2.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Vortice.Direct3D11.2.2.0\lib\netstandard2.0\Vortice.Direct3D11.dll</HintPath>
+    </Reference>
+    <Reference Include="Vortice.DirectX, Version=2.2.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Vortice.DirectX.2.2.0\lib\netstandard2.0\Vortice.DirectX.dll</HintPath>
+    </Reference>
+    <Reference Include="Vortice.DXGI, Version=2.2.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Vortice.DXGI.2.2.0\lib\netstandard2.0\Vortice.DXGI.dll</HintPath>
+    </Reference>
+    <Reference Include="Vortice.Mathematics, Version=1.4.0.0, Culture=neutral, PublicKeyToken=5431ec61a7e925da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Vortice.Mathematics.1.4.22\lib\netstandard2.0\Vortice.Mathematics.dll</HintPath>
+    </Reference>
+    <Reference Include="WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsBase_Core.STW.4.0.30319.1\lib\net40\WindowsBase.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiServer.cs" />
@@ -391,6 +416,11 @@
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Fody.6.3.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.3.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SharpGen.Runtime.2.0.0-beta.11\build\SharpGen.Runtime.props'))" />
+    <Error Condition="!Exists('..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SharpGen.Runtime.COM.2.0.0-beta.11\build\SharpGen.Runtime.COM.props'))" />
+    <Error Condition="!Exists('..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vortice.DirectX.2.2.0\build\Vortice.DirectX.props'))" />
+    <Error Condition="!Exists('..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vortice.DXGI.2.2.0\build\Vortice.DXGI.props'))" />
+    <Error Condition="!Exists('..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vortice.Direct3D11.2.2.0\build\Vortice.Direct3D11.props'))" />
   </Target>
   <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.1\build\Microsoft.CodeAnalysis.Analyzers.targets')" />
   <Import Project="..\packages\Fody.6.3.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.3.0\build\Fody.targets')" />

--- a/HyperionScreenCap/Program.cs
+++ b/HyperionScreenCap/Program.cs
@@ -50,13 +50,12 @@ namespace HyperionScreenCap
         ///
         private static void SetDpiAwareness()
         {
+            // Get windows version to set the correct dpi awareness context
+            // This is needed for DXGI 1.5 OutputDuplicate1 to work
             var query = "SELECT * FROM Win32_OperatingSystem";
             var searcher = new ManagementObjectSearcher(query);
             var info = searcher.Get().Cast<ManagementObject>().FirstOrDefault();
-//            var caption = info.Properties["Caption"].Value.ToString();
             var version = info.Properties["Version"].Value.ToString();
-//            var spMajorVersion = info.Properties["ServicePackMajorVersion"].Value.ToString();
-//            var spMinorVersion = info.Properties["ServicePackMinorVersion"].Value.ToString();
             Version winVersion = new Version(version);
             // Windows 8.1 added support for per monitor DPI
             if ( winVersion >= new Version(6, 3, 0))

--- a/HyperionScreenCap/Properties/AssemblyInfo.cs
+++ b/HyperionScreenCap/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Windows.Media;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.9.0.0")]
 //[assembly: AssemblyFileVersion("2.0.0.0")] Commented out so that it will be generated automatically
+
+// Needed for DuplicateOuput1 to work? :/
+[assembly: DisableDpiAwareness]

--- a/HyperionScreenCap/app.config
+++ b/HyperionScreenCap/app.config
@@ -114,7 +114,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/HyperionScreenCap/app.config
+++ b/HyperionScreenCap/app.config
@@ -114,7 +114,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -131,6 +131,14 @@
       <dependentAssembly>
         <assemblyIdentity name="Humanizer" publicKeyToken="979442b78dfc278e" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/HyperionScreenCap/packages.config
+++ b/HyperionScreenCap/packages.config
@@ -9,7 +9,6 @@
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Markdig" version="0.22.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net48" />
-  <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="3.8.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="3.8.0" targetFramework="net48" />
@@ -17,8 +16,9 @@
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="3.8.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="RestSharp" version="106.11.7" targetFramework="net48" />
-  <package id="SharpGen.Runtime" version="2.0.0-beta.11" targetFramework="net48" />
-  <package id="SharpGen.Runtime.COM" version="2.0.0-beta.11" targetFramework="net48" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
   <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
@@ -31,12 +31,7 @@
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
   <package id="System.Text.Encoding.CodePages" version="5.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
-  <package id="Vortice.Direct3D11" version="2.2.0" targetFramework="net48" />
-  <package id="Vortice.DirectX" version="2.2.0" targetFramework="net48" />
-  <package id="Vortice.DXGI" version="2.2.0" targetFramework="net48" />
-  <package id="Vortice.Mathematics" version="1.4.22" targetFramework="net48" />
-  <package id="WindowsBase_Core.STW" version="4.0.30319.1" targetFramework="net48" />
 </packages>

--- a/HyperionScreenCap/packages.config
+++ b/HyperionScreenCap/packages.config
@@ -9,6 +9,7 @@
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Markdig" version="0.22.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="3.8.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="3.8.0" targetFramework="net48" />
@@ -16,9 +17,8 @@
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="3.8.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="RestSharp" version="106.11.7" targetFramework="net48" />
-  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
-  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
-  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
+  <package id="SharpGen.Runtime" version="2.0.0-beta.11" targetFramework="net48" />
+  <package id="SharpGen.Runtime.COM" version="2.0.0-beta.11" targetFramework="net48" />
   <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
@@ -28,10 +28,15 @@
   <package id="System.Composition.Hosting" version="5.0.0" targetFramework="net48" />
   <package id="System.Composition.Runtime" version="5.0.0" targetFramework="net48" />
   <package id="System.Composition.TypedParts" version="5.0.0" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Text.Encoding.CodePages" version="5.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+  <package id="Vortice.Direct3D11" version="2.2.0" targetFramework="net48" />
+  <package id="Vortice.DirectX" version="2.2.0" targetFramework="net48" />
+  <package id="Vortice.DXGI" version="2.2.0" targetFramework="net48" />
+  <package id="Vortice.Mathematics" version="1.4.22" targetFramework="net48" />
+  <package id="WindowsBase_Core.STW" version="4.0.30319.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Add R16G16B16A16_Float support to the DX11Capture, allowing capturing of Windows HDR desktops (and games).
This change switches the use of DuplicateOutput to [DuplicateOutput1](https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_5/nf-dxgi1_5-idxgioutput5-duplicateoutput1), which enables capturing of non B8G8R8A8 buffer formats.

This also fixes the washed out and incorrect colors that were being passed to Hyperion when using a HDR format. A good example of this is Orange, which always resulted in Yellow.

Notes:
* To make DuplicateOuput1 work, the correct dpi awareness context needs to be set, else DXGI will fail with NOT_SUPPORTED.
* There is some strangeness I could not figure out where the 16bit floats in the captured buffer range from 0.0f to 4.6f, instead of 0 to 1. This is corrected by an arbitrary sqrt(x/4.6) formula, which ends up giving good results.

Screenshot of preview in Hyperion:
![image](https://user-images.githubusercontent.com/37940779/212210318-f5d56004-095b-4784-9346-0136ad660282.png)
