### PR TITLE
Auto-reinitialize stream if it fails

### DIFF
--- a/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
+++ b/HyperionScreenCap/Capture/Dx11ScreenCapture.cs
@@ -204,8 +204,8 @@ namespace HyperionScreenCap
                     ex.ResultCode == SharpDX.DXGI.ResultCode.DeviceRemoved ||
                     ex.ResultCode == SharpDX.DXGI.ResultCode.InvalidCall)
                 {
-                    LOG.Warn($"Capture failed due to device loss: {ex.Message}. Attempting to reinitialize.");
-                    Reinitialize();
+                    LOG.Warn($"Capture failed due to device loss: {ex.Message}. Disposing and signaling for reinitialization.");
+                    Dispose();
                     throw new CapturePausedException("Capture is paused due to device loss.");
                 }
                 else
@@ -219,31 +219,6 @@ namespace HyperionScreenCap
                 LOG.Error($"Capture failed: {ex.Message}", ex);
                 throw;
             }
-        }
-
-        private void Reinitialize()
-        {
-            Dispose();
-            int attempt = 0;
-            const int maxAttempts = 10;
-            const int delayBetweenAttempts = 1000; // milliseconds
-
-            while (attempt < maxAttempts)
-            {
-                try
-                {
-                    attempt++;
-                    Initialize();
-                    LOG.Info("Reinitialized capture successfully.");
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    LOG.Error($"Failed to reinitialize capture (attempt {attempt}/{maxAttempts}): {ex.Message}", ex);
-                    Thread.Sleep(delayBetweenAttempts);
-                }
-            }
-            throw new CapturePausedException("Failed to reinitialize capture after multiple attempts.");
         }
 
         private byte[] ManagedCapture()

--- a/HyperionScreenCap/Config/AppConstants.cs
+++ b/HyperionScreenCap/Config/AppConstants.cs
@@ -11,6 +11,11 @@ namespace HyperionScreenCap.Config
         public const int MAX_CAPTURE_ATTEMPTS = 45;
 
         /// <summary>
+        /// Delay in milliseconds before retrying after a pause
+        /// </summary>
+        public const int CAPTURE_PAUSED_RETRY_DELAY = 2000;
+
+        /// <summary>
         /// Number of screen capture failure attemps after which screen capture should be re-initialized.
         /// </summary>
         public const int REINIT_CAPTURE_AFTER_ATTEMPTS = 15;

--- a/HyperionScreenCap/Config/AppConstants.cs
+++ b/HyperionScreenCap/Config/AppConstants.cs
@@ -13,7 +13,7 @@ namespace HyperionScreenCap.Config
         /// <summary>
         /// Delay in milliseconds before retrying after a pause
         /// </summary>
-        public const int CAPTURE_PAUSED_RETRY_DELAY = 2000;
+        public const int CAPTURE_PAUSED_RETRY_DELAY = 3000;
 
         /// <summary>
         /// Number of screen capture failure attemps after which screen capture should be re-initialized.

--- a/HyperionScreenCap/Helper/UpdateChecker.cs
+++ b/HyperionScreenCap/Helper/UpdateChecker.cs
@@ -24,14 +24,14 @@ namespace HyperionScreenCap.Helper
         public UpdateChecker()
         {
             _restClient = new RestClient(GITHUB_API_BASE_URL);
-            RestRequest request = new RestRequest(GITHUB_LATEST_RELEASE_GET_URL, Method.GET);
-            IRestResponse<Release> response = _restClient.Execute<Release>(request);
+            RestRequest request = new RestRequest(GITHUB_LATEST_RELEASE_GET_URL, Method.Get); // Updated this line
+            RestResponse<Release> response = _restClient.Execute<Release>(request); // Updated this line
             LatestRelease = response.Data;
         }
 
         public bool IsUpdateAvailable()
         {
-            if ( LatestRelease != null )
+            if (LatestRelease != null)
             {
                 Version currVer = Assembly.GetExecutingAssembly().GetName().Version;
                 Version newVer;
@@ -39,12 +39,12 @@ namespace HyperionScreenCap.Helper
                 {
                     newVer = new Version(LatestRelease.tag_name.Replace(TAG_NAME_PREFIX, ""));
                 }
-                catch ( Exception ex )
+                catch (Exception ex)
                 {
                     LOG.Error($"Tag name ({LatestRelease.tag_name}) for the latest release has an unexpected format", ex);
                     newVer = ZERO_VERSION; // Fall back on 0.0
                 }
-                if ( newVer > currVer )
+                if (newVer > currVer)
                     return true;
             }
             return false;
@@ -54,7 +54,7 @@ namespace HyperionScreenCap.Helper
         {
             LOG.Info("Starting update check");
             UpdateChecker updateChecker = new UpdateChecker();
-            if ( updateChecker.IsUpdateAvailable() )
+            if (updateChecker.IsUpdateAvailable())
             {
                 Release latestRelease = updateChecker.LatestRelease;
                 StringBuilder bodyBuilder = new StringBuilder();
@@ -66,7 +66,7 @@ namespace HyperionScreenCap.Helper
                 bodyBuilder.Append("Would you like to download the update?");
                 DialogResult dialogResult = MessageBox.Show(bodyBuilder.ToString(), "Hyperion Screen Capture Update Available",
                     MessageBoxButtons.YesNo, MessageBoxIcon.Information);
-                if ( dialogResult == DialogResult.Yes )
+                if (dialogResult == DialogResult.Yes)
                 {
                     LOG.Info("Starting latest release download");
                     Process.Start(latestRelease.assets[0].browser_download_url);
@@ -74,7 +74,7 @@ namespace HyperionScreenCap.Helper
             }
             else
             {
-                if ( !isStartupCheck )
+                if (!isStartupCheck)
                 {
                     MessageBox.Show("No updates available. If you think this is an error, please check your internet connection.",
                         "Hyperion Screen Capture Update Check", MessageBoxButtons.OK);

--- a/HyperionScreenCap/HyperionScreenCap.csproj
+++ b/HyperionScreenCap/HyperionScreenCap.csproj
@@ -104,8 +104,8 @@
     <Reference Include="Markdig, Version=0.22.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdig.0.22.0\lib\net452\Markdig.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=3.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.3.8.0\lib\netstandard2.0\Microsoft.CodeAnalysis.dll</HintPath>
@@ -119,11 +119,11 @@
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=3.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.3.8.0\lib\netstandard2.0\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=112.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.112.0.0\lib\net48\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
@@ -141,8 +141,8 @@
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.5.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.8.0.0\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -163,25 +163,35 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.8.0.0\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encoding.CodePages.5.0.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=8.0.0.4, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.8.0.4\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />

--- a/HyperionScreenCap/Networking/HyperionClient.cs
+++ b/HyperionScreenCap/Networking/HyperionClient.cs
@@ -30,33 +30,33 @@ namespace HyperionScreenCap.Networking
             _messageDuration = messageDuration;
         }
 
-        public void Connect()
+        protected abstract void SendRegistrationMessage();
+        public abstract void SendInitialFrame(int width, int height);
+
+        public virtual void Connect()
         {
-            if ( _initLock || IsConnected() )
-            {
-                LOG.Info($"{this} already connected. Skipping request.");
-                return;
-            }
             _initLock = true;
             LOG.Info($"{this} Init lock set");
 
-            _socket = new TcpClient
-            {
-                SendTimeout = AppConstants.PROTO_CLIENT_SOCKET_TIMEOUT,
-                ReceiveTimeout = AppConstants.PROTO_CLIENT_SOCKET_TIMEOUT
-            };
-
             try
             {
+                _socket = new TcpClient
+                {
+                    SendTimeout = AppConstants.PROTO_CLIENT_SOCKET_TIMEOUT,
+                    ReceiveTimeout = AppConstants.PROTO_CLIENT_SOCKET_TIMEOUT
+                };
+
                 _socket.Connect(_host, _port);
                 _stream = _socket.GetStream();
+                Initialized = true;
+
+                SendRegistrationMessage(); // Moved here to ensure it's called after connecting
             }
             finally
             {
                 _initLock = false;
                 LOG.Info($"{this} Init lock unset");
             }
-            Initialized = true;
         }
 
         public bool IsConnected()

--- a/HyperionScreenCap/Networking/ProtoClient.cs
+++ b/HyperionScreenCap/Networking/ProtoClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Google.ProtocolBuffers;
 using proto;
+using static Humanizer.In;
 
 namespace HyperionScreenCap.Networking
 {
@@ -77,6 +78,23 @@ namespace HyperionScreenCap.Networking
         public override String ToString()
         {
             return $"ProtoClient[{_host}:{_port} ({_priority})]";
+        }
+
+        protected override void SendRegistrationMessage()
+        {
+            // Assuming there's no specific RegisterRequest, we'll use the general HyperionRequest
+            var request = proto.HyperionRequest.CreateBuilder()
+                .SetCommand(proto.HyperionRequest.Types.Command.COLOR) // Use an existing command
+                .Build();
+
+            SendRequest(request);
+        }
+
+        public override void SendInitialFrame(int width, int height)
+        {
+            // Send a black frame to initialize the connection
+            byte[] blackFrame = new byte[width * height * 3];
+            SendImageDataMessage(blackFrame, width, height);
         }
     }
 }

--- a/HyperionScreenCap/Networking/fbs/RawImage.cs
+++ b/HyperionScreenCap/Networking/fbs/RawImage.cs
@@ -33,20 +33,40 @@ public struct RawImage : IFlatbufferObject
   public int Height { get { int o = __p.__offset(8); return o != 0 ? __p.bb.GetInt(o + __p.bb_pos) : (int)-1; } }
   public bool MutateHeight(int height) { int o = __p.__offset(8); if (o != 0) { __p.bb.PutInt(o + __p.bb_pos, height); return true; } else { return false; } }
 
-  public static Offset<hyperionnet.RawImage> CreateRawImage(FlatBufferBuilder builder,
-      VectorOffset dataOffset = default(VectorOffset),
-      int width = -1,
-      int height = -1) {
+public static Offset<hyperionnet.RawImage> CreateRawImage(FlatBufferBuilder builder,
+    VectorOffset dataOffset = default(VectorOffset),
+    int width = -1,
+    int height = -1)
+{
     builder.StartTable(3);
     RawImage.AddHeight(builder, height);
     RawImage.AddWidth(builder, width);
-    RawImage.AddData(builder, dataOffset);
+    if (dataOffset.Value != 0) // Check if data is not null
+    {
+        RawImage.AddData(builder, dataOffset);
+    }
     return RawImage.EndRawImage(builder);
-  }
+}
 
   public static void StartRawImage(FlatBufferBuilder builder) { builder.StartTable(3); }
   public static void AddData(FlatBufferBuilder builder, VectorOffset dataOffset) { builder.AddOffset(0, dataOffset.Value, 0); }
-  public static VectorOffset CreateDataVector(FlatBufferBuilder builder, byte[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte(data[i]); return builder.EndVector(); }
+
+  public static VectorOffset CreateDataVector(FlatBufferBuilder builder, byte[] data)
+  {
+      if (data == null || data.Length == 0) // Handle null or empty data case
+      {
+          // Return an empty vector if data is null or empty to avoid crashing
+          return builder.EndVector();
+      }
+
+      builder.StartVector(1, data.Length, 1);
+      for (int i = data.Length - 1; i >= 0; i--)
+      {
+          builder.AddByte(data[i]);
+      }
+      return builder.EndVector();
+  }
+
   public static VectorOffset CreateDataVectorBlock(FlatBufferBuilder builder, byte[] data) { builder.StartVector(1, data.Length, 1); builder.Add(data); return builder.EndVector(); }
   public static void StartDataVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
   public static void AddWidth(FlatBufferBuilder builder, int width) { builder.AddInt(1, width, -1); }

--- a/HyperionScreenCap/Properties/AssemblyInfo.cs
+++ b/HyperionScreenCap/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.9.0.0")]
+[assembly: AssemblyVersion("2.9.0.2")]
 //[assembly: AssemblyFileVersion("2.0.0.0")] Commented out so that it will be generated automatically

--- a/HyperionScreenCap/Properties/AssemblyInfo.cs
+++ b/HyperionScreenCap/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.9.0.2")]
+[assembly: AssemblyVersion("2.9.0.3")]
 //[assembly: AssemblyFileVersion("2.0.0.0")] Commented out so that it will be generated automatically

--- a/HyperionScreenCap/app.config
+++ b/HyperionScreenCap/app.config
@@ -106,7 +106,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -114,7 +114,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -126,11 +126,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Humanizer" publicKeyToken="979442b78dfc278e" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/HyperionScreenCap/packages.config
+++ b/HyperionScreenCap/packages.config
@@ -8,30 +8,33 @@
   <package id="Humanizer.Core" version="2.8.26" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Markdig" version="0.22.0" targetFramework="net48" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="3.8.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="3.8.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="3.8.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="3.8.0" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="RestSharp" version="106.11.7" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="RestSharp" version="112.0.0" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
   <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="8.0.0" targetFramework="net48" />
   <package id="System.Composition" version="5.0.0" targetFramework="net48" />
   <package id="System.Composition.AttributedModel" version="5.0.0" targetFramework="net48" />
   <package id="System.Composition.Convention" version="5.0.0" targetFramework="net48" />
   <package id="System.Composition.Hosting" version="5.0.0" targetFramework="net48" />
   <package id="System.Composition.Runtime" version="5.0.0" targetFramework="net48" />
   <package id="System.Composition.TypedParts" version="5.0.0" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
-  <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="8.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Text.Encoding.CodePages" version="5.0.0" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="8.0.4" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Fixed the issue where certain things like UAC prompts, Fullscreen games, resolution changes etc. would stop the capture from working and require a manual restart. The system should now reliably re-initialize itself. Would recommend disabling sidebar notifications for this program in the windows sidebar as it will pop up a connection notification whenever this happens.